### PR TITLE
refactor: use null instead of optional

### DIFF
--- a/src/main/kotlin/reminder/application/ReminderSaver.kt
+++ b/src/main/kotlin/reminder/application/ReminderSaver.kt
@@ -1,7 +1,6 @@
 package reminder.application
 
 import reminder.domain.*
-import java.util.*
 
 class ReminderSaver(
     private val repository: ReminderRepository,
@@ -15,11 +14,11 @@ class ReminderSaver(
      * @see ReminderIdentifierGenerator
      * @return The saved reminder instance
      */
-    fun save(title: String, description: Optional<String>): Reminder {
+    fun save(title: String, description: String?): Reminder {
         val reminder = Reminder(
             id = identifierGenerator.generate(),
             title = Title(title),
-            description = description.map { Description(it) })
+            description = description?.let { Description(it) })
         repository.save(reminder)
         return reminder
     }

--- a/src/main/kotlin/reminder/application/ReminderSearcher.kt
+++ b/src/main/kotlin/reminder/application/ReminderSearcher.kt
@@ -1,7 +1,8 @@
 package reminder.application
 
-import reminder.domain.*
-import java.util.*
+import reminder.domain.Reminder
+import reminder.domain.ReminderIdentifier
+import reminder.domain.ReminderRepository
 
 class ReminderSearcher(
     private val repository: ReminderRepository,
@@ -10,7 +11,7 @@ class ReminderSearcher(
     /***
      * Searches a Reminder with the given identifier and returns it if found.
      * @see Reminder
-     * @return An optional of a reminder instance.
+     * @return null or a reminder instance if it exists
      */
     fun search(identifier: ReminderIdentifier) = repository.search(identifier)
 

--- a/src/main/kotlin/reminder/domain/Reminder.kt
+++ b/src/main/kotlin/reminder/domain/Reminder.kt
@@ -1,5 +1,3 @@
 package reminder.domain
 
-import java.util.*
-
-data class Reminder(val id: ReminderIdentifier, val title: Title, val description: Optional<Description>)
+data class Reminder(val id: ReminderIdentifier, val title: Title, val description: Description?)

--- a/src/main/kotlin/reminder/domain/ReminderRepository.kt
+++ b/src/main/kotlin/reminder/domain/ReminderRepository.kt
@@ -1,8 +1,6 @@
 package reminder.domain
 
-import java.util.*
-
 interface ReminderRepository {
     fun save(reminder: Reminder)
-    fun search(identifier: ReminderIdentifier): Optional<Reminder>
+    fun search(identifier: ReminderIdentifier): Reminder?
 }

--- a/src/test/kotlin/reminder/application/ReminderSaverTest.kt
+++ b/src/test/kotlin/reminder/application/ReminderSaverTest.kt
@@ -9,7 +9,6 @@ import reminder.domain.ReminderIdentifierGenerator
 import reminder.domain.ReminderRepository
 import reminder.domain.exceptions.IllegalTitleException
 import reminder.mothers.ReminderMother
-import java.util.*
 import kotlin.test.assertEquals
 
 class ReminderSaverTest {
@@ -28,7 +27,7 @@ class ReminderSaverTest {
     @Test
     fun `Empty title throws IllegalTitleException`() {
         assertThrows<IllegalTitleException> {
-            reminderSaver.save("", Optional.empty())
+            reminderSaver.save("", null)
         }
     }
 

--- a/src/test/kotlin/reminder/application/ReminderSearcherTest.kt
+++ b/src/test/kotlin/reminder/application/ReminderSearcherTest.kt
@@ -3,12 +3,10 @@ package reminder.application
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
-import reminder.domain.Reminder
 import reminder.domain.ReminderIdentifierGenerator
 import reminder.domain.ReminderRepository
 import reminder.mothers.IdentifierMother
 import reminder.mothers.ReminderMother
-import java.util.*
 import kotlin.test.assertEquals
 
 class ReminderSearcherTest {
@@ -27,23 +25,23 @@ class ReminderSearcherTest {
     fun `Nothing is returned when valid identifier doesn't exist in the repository`() {
         // Initialize
         val identifier = IdentifierMother.getValidIdentifier()
-        Mockito.`when`(repository.search(identifier)).thenReturn(Optional.empty())
+        Mockito.`when`(repository.search(identifier)).thenReturn(null)
         // Execute
         val result = reminderSearcher.search(identifier)
         // Assert
         Mockito.verify(repository, Mockito.times(1)).search(identifier)
-        assertEquals(Optional.empty<Reminder>(), result)
+        assertEquals(null, result)
     }
 
     @Test
     fun `Reminder is returned when identifier exists in the repository`() {
         // Initialize
         val reminder = ReminderMother.getValidReminderWithoutDescription()
-        Mockito.`when`(repository.search(reminder.id)).thenReturn(Optional.of(reminder))
+        Mockito.`when`(repository.search(reminder.id)).thenReturn(reminder)
         // Execute
         val result = reminderSearcher.search(reminder.id)
         // Assert
         Mockito.verify(repository, Mockito.times(1)).search(reminder.id)
-        assertEquals(Optional.of(reminder), result)
+        assertEquals(reminder, result)
     }
 }

--- a/src/test/kotlin/reminder/mothers/DescriptionMother.kt
+++ b/src/test/kotlin/reminder/mothers/DescriptionMother.kt
@@ -5,8 +5,8 @@ import reminder.domain.Description
 class DescriptionMother {
 
     companion object {
-        private fun getPrimitiveValidDescription() = "Buy Milk"
-        fun getValidDescription() = Description(getPrimitiveValidDescription())
+        private const val PRIMITIVE_DESCRIPTION = "I should buy some milk, because if I don't I can't do coffee"
+        fun getValidDescription() = Description(PRIMITIVE_DESCRIPTION)
         fun getPrimitiveFrom(description: Description) = description.description
     }
 }

--- a/src/test/kotlin/reminder/mothers/DescriptionMother.kt
+++ b/src/test/kotlin/reminder/mothers/DescriptionMother.kt
@@ -7,6 +7,6 @@ class DescriptionMother {
     companion object {
         private fun getPrimitiveValidDescription() = "Buy Milk"
         fun getValidDescription() = Description(getPrimitiveValidDescription())
-        fun getPrimitiveFrom(description: Description): String = description.description
+        fun getPrimitiveFrom(description: Description) = description.description
     }
 }

--- a/src/test/kotlin/reminder/mothers/IdentifierMother.kt
+++ b/src/test/kotlin/reminder/mothers/IdentifierMother.kt
@@ -5,6 +5,7 @@ import reminder.domain.ReminderIdentifier
 class IdentifierMother {
 
     companion object {
-        fun getValidIdentifier() = ReminderIdentifier("414243db-8d26-4be3-bcb2-cc91c8f95957")
+        private const val PRIMITIVE_REMINDER_IDENTIFIER = "414243db-8d26-4be3-bcb2-cc91c8f95957"
+        fun getValidIdentifier() = ReminderIdentifier(PRIMITIVE_REMINDER_IDENTIFIER)
     }
 }

--- a/src/test/kotlin/reminder/mothers/ReminderMother.kt
+++ b/src/test/kotlin/reminder/mothers/ReminderMother.kt
@@ -1,7 +1,6 @@
 package reminder.mothers
 
 import reminder.domain.Reminder
-import java.util.*
 
 class ReminderMother {
 
@@ -9,17 +8,17 @@ class ReminderMother {
         fun getValidReminderWithDescription() = Reminder(
             id = IdentifierMother.getValidIdentifier(),
             title = TitleMother.getValidTitle(),
-            description = Optional.of(DescriptionMother.getValidDescription())
+            description = DescriptionMother.getValidDescription()
         )
 
         fun getValidReminderWithoutDescription() = Reminder(
             id = IdentifierMother.getValidIdentifier(),
             title = TitleMother.getValidTitle(),
-            description = Optional.empty()
+            description = null
         )
 
         fun getTitlePrimitiveFrom(reminder: Reminder) = TitleMother.getPrimitiveFrom(reminder.title)
-        fun getDescriptionPrimitiveFrom(reminder: Reminder): Optional<String> =
-            reminder.description.map { DescriptionMother.getPrimitiveFrom(it) }
+        fun getDescriptionPrimitiveFrom(reminder: Reminder): String? =
+            reminder.description?.let { DescriptionMother.getPrimitiveFrom(it) }
     }
 }

--- a/src/test/kotlin/reminder/mothers/TitleMother.kt
+++ b/src/test/kotlin/reminder/mothers/TitleMother.kt
@@ -5,8 +5,8 @@ import reminder.domain.Title
 class TitleMother {
 
     companion object {
-        private fun getValidTitlePrimitive(): String = "I should buy some milk, because if I don't I can't do coffee"
-        fun getValidTitle(): Title = Title(getValidTitlePrimitive())
+        private const val PRIMITIVE_TITLE = "Buy Milk"
+        fun getValidTitle() = Title(PRIMITIVE_TITLE)
         fun getPrimitiveFrom(title: Title) = title.title
     }
 


### PR DESCRIPTION
Kotlin already aplies a very good null safety mechanism, that "deprecates" the java Optional class. From the Kotlin in Action book:

*Another path to solving this problem (NullPointerException) is to never use null values in code and to use a special wrapper type, such as the Optional type introduced in Java 8, to represent values that may or may not be defined. This approach has several downsides: the code gets more verbose, the extra wrapper instances affect performance at runtime, and it's not used consistently accross the entire ecosystem. Even if you do use Optional everywhen in your own code, you'll still need to deal with null vaules returned from methods of the JDK, The Android Framework, and other third-party libraries.*

Using null instead of optional would allow us to use the kotlin safe call operator (?), the elvis operator (?:) and "let"  which consequently means writing less code for the same logic.

I would recommend to merge this first before @oriolagobat does the requested changes on #16