### PR TITLE
refactor: make deadline creator domain-language aware

### DIFF
--- a/src/main/kotlin/deadline/application/DeadlineCreator.kt
+++ b/src/main/kotlin/deadline/application/DeadlineCreator.kt
@@ -7,7 +7,7 @@ import deadline.domain.exceptions.AlreadyConfiguredDeadline
 import shared.domain.Identifier
 import shared.domain.exceptions.InvalidUUIDException
 
-class CreateDeadline(private val repository: DeadlineRepository) {
+class DeadlineCreator(private val repository: DeadlineRepository) {
 
     /***
      * Creates a new deadline and saves it to the DeadlineRepository

--- a/src/main/kotlin/deadline/application/DeadlineCreator.kt
+++ b/src/main/kotlin/deadline/application/DeadlineCreator.kt
@@ -17,8 +17,10 @@ class DeadlineCreator(private val repository: DeadlineRepository) {
      */
     fun create(primitives: DeadlinePrimitives) = create(Identifier(primitives.noteIdentifier), Time(primitives.time))
 
-    private fun create(noteId: Identifier, time: Time): Deadline {
-        val deadline = repository.get(noteId)?.let { throw AlreadyConfiguredDeadline() } ?: Deadline(noteId, time)
+    private fun create(noteId: Identifier, time: Time) = save(Deadline(noteId, time))
+
+    private fun save(deadline: Deadline): Deadline {
+        repository.get(deadline.noteId)?.let { throw AlreadyConfiguredDeadline() }
         repository.save(deadline)
         return deadline
     }

--- a/src/test/kotlin/deadline/application/DeadlineCreatorTest.kt
+++ b/src/test/kotlin/deadline/application/DeadlineCreatorTest.kt
@@ -9,15 +9,15 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito
 import kotlin.test.assertEquals
 
-class CreateDeadlineTest {
+class DeadlineCreatorTest {
 
     private lateinit var repository: DeadlineRepository
-    private lateinit var useCase: CreateDeadline
+    private lateinit var useCase: DeadlineCreator
 
     @BeforeEach
     fun `Set Up`() {
         repository = Mockito.mock(DeadlineRepository::class.java)
-        useCase = CreateDeadline(repository)
+        useCase = DeadlineCreator(repository)
     }
 
     @Test


### PR DESCRIPTION
This makes the "create a deadline" use case be aware of the domain-language we stated on discussion #43 .

If you don't like this type of language, request changes to the pull request and discuss your point of view on the discussion.