### PR TITLE
refactor: use domain language

### DIFF
--- a/src/main/kotlin/deadline/application/DeadlineCreator.kt
+++ b/src/main/kotlin/deadline/application/DeadlineCreator.kt
@@ -17,11 +17,11 @@ class DeadlineCreator(private val repository: DeadlineRepository) {
      */
     fun create(primitives: DeadlinePrimitives) = create(Identifier(primitives.noteIdentifier), Time(primitives.time))
 
-    private fun create(noteId: Identifier, time: Time) = save(Deadline(noteId, time))
+    private fun create(noteId: Identifier, time: Time) = create(Deadline(noteId, time))
 
-    private fun save(deadline: Deadline): Deadline {
-        repository.get(deadline.noteId)?.let { throw AlreadyConfiguredDeadline() }
-        repository.save(deadline)
+    private fun create(deadline: Deadline): Deadline {
+        repository.search(deadline.noteId)?.let { throw AlreadyConfiguredDeadline() }
+        repository.create(deadline)
         return deadline
     }
 }

--- a/src/main/kotlin/deadline/domain/DeadlineRepository.kt
+++ b/src/main/kotlin/deadline/domain/DeadlineRepository.kt
@@ -3,6 +3,6 @@ package deadline.domain
 import shared.domain.Identifier
 
 interface DeadlineRepository {
-    fun save(deadline: Deadline)
-    fun get(noteIdentifier: Identifier): Deadline?
+    fun create(deadline: Deadline)
+    fun search(noteIdentifier: Identifier): Deadline?
 }

--- a/src/main/kotlin/note/application/NoteChanger.kt
+++ b/src/main/kotlin/note/application/NoteChanger.kt
@@ -36,7 +36,7 @@ class NoteChanger(
     }
 
     private fun updateNote(oldNoteId: Identifier, newNote: NotePrimitives): Note {
-        val result = NoteCreator(repository).save(newNote)
+        val result = NoteCreator(repository).create(newNote)
         repository.remove(oldNoteId)
         return result
     }

--- a/src/main/kotlin/note/application/NoteCreator.kt
+++ b/src/main/kotlin/note/application/NoteCreator.kt
@@ -23,14 +23,14 @@ class NoteCreator(
      * @see Note
      * @return The saved note instance
      */
-    fun save(note: NotePrimitives): Note {
+    fun create(note: NotePrimitives): Note {
         val noteId = Identifier(note.noteId)
         val title = Title(note.title)
         val description = note.description?.let { Description(it) }
-        return save(noteId, title, description)
+        return create(noteId, title, description)
     }
 
-    private fun save(noteId: Identifier, title: Title, description: Description?): Note {
+    private fun create(noteId: Identifier, title: Title, description: Description?): Note {
         val newNote = Note(
             id = noteId,
             title = title,

--- a/src/test/kotlin/deadline/application/DeadlineCreatorTest.kt
+++ b/src/test/kotlin/deadline/application/DeadlineCreatorTest.kt
@@ -26,7 +26,7 @@ class DeadlineCreatorTest {
         val noteIdentifier = DeadlineMother.getNoteIdentifierFromDeadline(currentDeadline)
         val deadlinePrimitive = DeadlineMother.getPrimitivesFrom(currentDeadline)
 
-        Mockito.`when`(repository.get(noteIdentifier)).thenReturn(currentDeadline)
+        Mockito.`when`(repository.search(noteIdentifier)).thenReturn(currentDeadline)
 
         assertThrows<AlreadyConfiguredDeadline> { useCase.create(deadlinePrimitive) }
     }
@@ -37,10 +37,10 @@ class DeadlineCreatorTest {
         val noteIdentifier = DeadlineMother.getNoteIdentifierFromDeadline(deadline)
         val deadlinePrimitive = DeadlineMother.getPrimitivesFrom(deadline)
 
-        Mockito.`when`(repository.get(noteIdentifier)).thenReturn(null)
+        Mockito.`when`(repository.search(noteIdentifier)).thenReturn(null)
         val resultingDeadline = useCase.create(deadlinePrimitive)
 
         assertEquals(deadline, resultingDeadline)
-        Mockito.verify(repository, Mockito.times(1)).save(deadline)
+        Mockito.verify(repository, Mockito.times(1)).create(deadline)
     }
 }

--- a/src/test/kotlin/note/application/NoteCreatorTest.kt
+++ b/src/test/kotlin/note/application/NoteCreatorTest.kt
@@ -13,15 +13,15 @@ import shared.domain.exceptions.InvalidUUIDException
 import shared.mothers.IdentifierMother
 import kotlin.test.assertEquals
 
-class NoteSaverTest {
+class NoteCreatorTest {
 
-    private lateinit var noteSaver: NoteCreator
+    private lateinit var noteCreator: NoteCreator
     private lateinit var repository: NoteRepository
 
     @BeforeEach
     fun setUp() {
         repository = Mockito.mock(NoteRepository::class.java)
-        noteSaver = NoteCreator(repository)
+        noteCreator = NoteCreator(repository)
     }
 
     @Test
@@ -29,7 +29,7 @@ class NoteSaverTest {
         val notePrimitives = NoteMother.getValidNoteWithDescription().toPrimitives()
         val invalidTitlePrimitives = notePrimitives.copy(title = "")
         assertThrows<IllegalTitleException> {
-            noteSaver.save(invalidTitlePrimitives)
+            noteCreator.create(invalidTitlePrimitives)
         }
     }
 
@@ -38,7 +38,7 @@ class NoteSaverTest {
         val note = NoteMother.getValidNoteWithDescription().toPrimitives()
         val invalidIdPrimitive = note.copy(noteId = IdentifierMother.invalidPrimitiveIdentifier)
         assertThrows<InvalidUUIDException> {
-            noteSaver.save(invalidIdPrimitive)
+            noteCreator.create(invalidIdPrimitive)
         }
     }
 
@@ -48,7 +48,7 @@ class NoteSaverTest {
         val noteId = NoteMother.getIdentifierFrom(note)
         Mockito.`when`(repository.search(noteId)).thenReturn(note)
         assertThrows<AlreadyUsedIdentifierException> {
-            noteSaver.save(note.toPrimitives())
+            noteCreator.create(note.toPrimitives())
         }
     }
 
@@ -65,7 +65,7 @@ class NoteSaverTest {
     }
 
     private fun `Assert that the note was saved to the repository given the primitives from`(note: Note) {
-        val result = noteSaver.save(note.toPrimitives())
+        val result = noteCreator.create(note.toPrimitives())
 
         Mockito.verify(repository, Mockito.times(1)).create(note)
         assertEquals(note, result)


### PR DESCRIPTION
`DeadlineRepository` was using the old convention for searcher use cases.